### PR TITLE
feat: add user-specified partition metadata table DB + refactor

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -19,16 +19,15 @@ package org.apache.beam.sdk.io.gcp.spanner;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.beam.sdk.io.gcp.spanner.MutationUtils.isPointDelete;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.NameGenerator.generateMetadataTableName;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.NameGenerator.generatePartitionMetadataTableName;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import avro.shaded.com.google.common.base.Objects;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.ServiceFactory;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbortedException;
-import com.google.cloud.spanner.DatabaseAdminClient;
-import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.KeySet;
@@ -60,7 +59,6 @@ import org.apache.beam.sdk.io.gcp.spanner.cdc.PostProcessingMetricsDoFn;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.ReadChangeStreamPartitionDoFn;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.actions.ActionFactory;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.dao.DaoFactory;
-import org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.mapper.MapperFactory;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.model.DataChangeRecord;
 import org.apache.beam.sdk.metrics.Counter;
@@ -1282,6 +1280,8 @@ public class SpannerIO {
 
     abstract String getChangeStreamName();
 
+    abstract String getMetadataDatabase();
+
     abstract Timestamp getInclusiveStartAt();
 
     abstract @Nullable Timestamp getInclusiveEndAt();
@@ -1296,6 +1296,8 @@ public class SpannerIO {
       abstract Builder setSpannerConfig(SpannerConfig spannerConfig);
 
       abstract Builder setChangeStreamName(String changeStreamName);
+
+      abstract Builder setMetadataDatabase(String metadataDatabase);
 
       abstract Builder setInclusiveStartAt(Timestamp inclusiveStartAt);
 
@@ -1349,6 +1351,11 @@ public class SpannerIO {
       return toBuilder().setChangeStreamName(changeStreamName).build();
     }
 
+    /** Specifies the metadata database. */
+    public ReadChangeStream withMetadataDatabase(String metadataDatabase) {
+      return toBuilder().setMetadataDatabase(metadataDatabase).build();
+    }
+
     /** Specifies the time that the change stream should be read from. */
     public ReadChangeStream withInclusiveStartAt(Timestamp timestamp) {
       return toBuilder().setInclusiveStartAt(timestamp).build();
@@ -1394,51 +1401,47 @@ public class SpannerIO {
         throw new IllegalArgumentException("Start time cannot be after end time.");
       }
 
-      final SpannerAccessor spannerAccessor = SpannerAccessor.getOrCreate(getSpannerConfig());
-      final DatabaseAdminClient databaseAdminClient = spannerAccessor.getDatabaseAdminClient();
-      final DatabaseClient databaseClient = spannerAccessor.getDatabaseClient();
-      final DatabaseId databaseId =
+      final DatabaseId changeStreamDatabaseId =
           DatabaseId.of(
               getSpannerConfig().getProjectId().get(),
               getSpannerConfig().getInstanceId().get(),
               getSpannerConfig().getDatabaseId().get());
+      final String partitionMetadataDatabaseId =
+          Objects.firstNonNull(getMetadataDatabase(), changeStreamDatabaseId.getDatabase());
+      final String partitionMetadataTableName =
+          generatePartitionMetadataTableName(partitionMetadataDatabaseId);
 
-      final String partitionMetadataTableName = generateMetadataTableName(databaseId.getDatabase());
+      final SpannerConfig changeStreamSpannerConfig = getSpannerConfig();
+      final SpannerConfig partitionMetadataSpannerConfig =
+          SpannerConfig.create()
+              .withProjectId(changeStreamSpannerConfig.getProjectId())
+              .withInstanceId(changeStreamSpannerConfig.getInstanceId())
+              .withDatabaseId(partitionMetadataDatabaseId)
+              .withCommitDeadline(changeStreamSpannerConfig.getCommitDeadline())
+              .withEmulatorHost(changeStreamSpannerConfig.getEmulatorHost())
+              .withMaxCumulativeBackoff(changeStreamSpannerConfig.getMaxCumulativeBackoff());
+      final DaoFactory daoFactory =
+          new DaoFactory(
+              changeStreamSpannerConfig,
+              getChangeStreamName(),
+              partitionMetadataSpannerConfig,
+              partitionMetadataTableName);
 
-      // FIXME: This should be removed and only the dao factory should be used
-      final PartitionMetadataDao partitionMetadataDao =
-          new PartitionMetadataDao(partitionMetadataTableName, databaseClient);
+      final DetectNewPartitionsDoFn detectNewPartitionsDoFn =
+          new DetectNewPartitionsDoFn(daoFactory.getPartitionMetadataDao());
+      final ReadChangeStreamPartitionDoFn readChangeStreamPartitionDoFn =
+          new ReadChangeStreamPartitionDoFn(daoFactory, new MapperFactory(), new ActionFactory());
+      final PostProcessingMetricsDoFn postProcessingMetricsDoFn = new PostProcessingMetricsDoFn();
 
-      // TODO: See if we can remove the metadata table name from the source
+      PipelineInitializer.initialize(
+          daoFactory.getPartitionMetadataAdminDao(),
+          daoFactory.getPartitionMetadataDao(),
+          getInclusiveStartAt(),
+          getInclusiveEndAt());
       final List<ChangeStreamSourceDescriptor> sources = new ArrayList<>();
       sources.add(
           ChangeStreamSourceDescriptor.of(
-              getChangeStreamName(),
-              partitionMetadataTableName,
-              getInclusiveStartAt(),
-              getInclusiveEndAt()));
-      // FIXME: This should come from the generated table name
-      final DaoFactory daoFactory =
-          new DaoFactory(getChangeStreamName(), partitionMetadataTableName);
-      final MapperFactory mapperFactory = new MapperFactory();
-      final ActionFactory actionFactory = new ActionFactory();
-      // FIXME: We should use the DAOFactory here instead of passing in the table name
-      final DetectNewPartitionsDoFn detectNewPartitionsDoFn =
-          new DetectNewPartitionsDoFn(getSpannerConfig(), partitionMetadataTableName);
-      final ReadChangeStreamPartitionDoFn readChangeStreamPartitionDoFn =
-          new ReadChangeStreamPartitionDoFn(
-              getSpannerConfig(), daoFactory, mapperFactory, actionFactory);
-      final PostProcessingMetricsDoFn postProcessingMetricsDoFn = new PostProcessingMetricsDoFn();
-
-      // FIXME: Remove the partitionMetadataDAO as a parameter
-      // TODO: See if we can have a DAO for the admin operations
-      PipelineInitializer.initialize(
-          databaseAdminClient,
-          partitionMetadataDao,
-          databaseId,
-          partitionMetadataTableName,
-          getInclusiveStartAt(),
-          getInclusiveEndAt());
+              getChangeStreamName(), getInclusiveStartAt(), getInclusiveEndAt()));
       return input
           .apply("Generate change stream sources", Create.of(sources))
           .apply("Detect new partitions", ParDo.of(detectNewPartitionsDoFn))

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1428,7 +1428,7 @@ public class SpannerIO {
               partitionMetadataTableName);
 
       final DetectNewPartitionsDoFn detectNewPartitionsDoFn =
-          new DetectNewPartitionsDoFn(daoFactory.getPartitionMetadataDao());
+          new DetectNewPartitionsDoFn(daoFactory);
       final ReadChangeStreamPartitionDoFn readChangeStreamPartitionDoFn =
           new ReadChangeStreamPartitionDoFn(daoFactory, new MapperFactory(), new ActionFactory());
       final PostProcessingMetricsDoFn postProcessingMetricsDoFn = new PostProcessingMetricsDoFn();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/ChangeStreamSourceDescriptor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/ChangeStreamSourceDescriptor.java
@@ -28,17 +28,15 @@ import javax.annotation.Nullable;
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public abstract class ChangeStreamSourceDescriptor implements Serializable {
-  abstract String getChangeStreamName();
 
-  abstract String getMetadataTableName();
+  abstract String getChangeStreamName();
 
   abstract @Nullable Timestamp getStartAt();
 
   abstract @Nullable Timestamp getEndAt();
 
   public static ChangeStreamSourceDescriptor of(
-      String changeStreamName, String metadataTableName, Timestamp startAt, Timestamp endAt) {
-    return new AutoValue_ChangeStreamSourceDescriptor(
-        changeStreamName, metadataTableName, startAt, endAt);
+      String changeStreamName, Timestamp startAt, Timestamp endAt) {
+    return new AutoValue_ChangeStreamSourceDescriptor(changeStreamName, startAt, endAt);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/DetectNewPartitionsDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/DetectNewPartitionsDoFn.java
@@ -20,13 +20,10 @@ package org.apache.beam.sdk.io.gcp.spanner.cdc;
 import static org.apache.beam.sdk.io.gcp.spanner.cdc.CdcMetrics.PARTITIONS_DETECTED_COUNTER;
 import static org.apache.beam.sdk.io.gcp.spanner.cdc.CdcMetrics.PARTITION_CREATED_TO_SCHEDULED_MS;
 
-import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.ResultSet;
-import com.google.cloud.spanner.Statement;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.model.PartitionMetadata;
+import org.apache.beam.sdk.io.gcp.spanner.cdc.model.PartitionMetadata.State;
 import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
@@ -57,23 +54,19 @@ import org.slf4j.LoggerFactory;
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class DetectNewPartitionsDoFn extends DoFn<ChangeStreamSourceDescriptor, PartitionMetadata> {
-  private static final Logger LOG = LoggerFactory.getLogger(DetectNewPartitionsDoFn.class);
-  private SpannerAccessor spannerAccessor;
-  private DatabaseClient databaseClient;
-  private SpannerConfig spannerConfig;
-  // TODO(hengfeng): Make this field configurable via constructor or spanner config.
-  private Duration resumeDuration = Duration.millis(100L);;
-  private String metadataTableName;
-  private PartitionMetadataDao partitionMetadataDao;
 
-  public DetectNewPartitionsDoFn(SpannerConfig config, String metadataTableName) {
-    this.spannerConfig = config;
-    this.metadataTableName = metadataTableName;
+  private static final Logger LOG = LoggerFactory.getLogger(DetectNewPartitionsDoFn.class);
+  // TODO(hengfeng): Make this field configurable via constructor or spanner config.
+  private Duration resumeDuration = Duration.millis(100L);
+  private final PartitionMetadataDao partitionMetadataDao;
+
+  public DetectNewPartitionsDoFn(PartitionMetadataDao partitionMetadataDao) {
+    this.partitionMetadataDao = partitionMetadataDao;
   }
 
   public DetectNewPartitionsDoFn(
-      SpannerConfig config, String metadataTableName, Duration resumeDuration) {
-    this(config, metadataTableName);
+      PartitionMetadataDao partitionMetadataDao, Duration resumeDuration) {
+    this(partitionMetadataDao);
     this.resumeDuration = resumeDuration;
   }
 
@@ -100,35 +93,16 @@ public class DetectNewPartitionsDoFn extends DoFn<ChangeStreamSourceDescriptor, 
     return new OffsetRangeTracker(new OffsetRange(restriction.getFrom(), restriction.getTo()));
   }
 
-  @Setup
-  public void setup() throws Exception {
-    this.spannerAccessor = SpannerAccessor.getOrCreate(this.spannerConfig);
-    this.databaseClient = spannerAccessor.getDatabaseClient();
-    this.partitionMetadataDao =
-        new PartitionMetadataDao(this.metadataTableName, this.databaseClient);
-  }
-
-  @Teardown
-  public void teardown() throws Exception {
-    this.spannerAccessor.close();
-  }
-
   @ProcessElement
   public ProcessContinuation processElement(
       @Element ChangeStreamSourceDescriptor inputElement,
       RestrictionTracker<OffsetRange, Long> tracker,
       WatermarkEstimator watermarkEstimator,
       OutputReceiver<PartitionMetadata> receiver) {
-
     Instant start = Instant.now();
-
     LOG.debug("Calling process element:" + start);
 
-    // Find all records where their states are CREATED.
-    // TODO(hengfeng): move this to DAO.
-    String query =
-        String.format("SELECT * FROM `%s` WHERE State = 'CREATED'", this.metadataTableName);
-    try (ResultSet resultSet = this.databaseClient.singleUse().executeQuery(Statement.of(query))) {
+    try (ResultSet resultSet = partitionMetadataDao.getPartitionsInState(State.CREATED)) {
       long currentIndex = tracker.currentRestriction().getFrom();
 
       // Output the records.
@@ -144,7 +118,6 @@ public class DetectNewPartitionsDoFn extends DoFn<ChangeStreamSourceDescriptor, 
         PARTITION_CREATED_TO_SCHEDULED_MS.update(
             new Duration(metadata.getCreatedAt().toDate().getTime(), Instant.now().getMillis())
                 .getMillis());
-
         LOG.debug(
             String.format(
                 "Get partition metadata currentIndex:%d meta:%s", currentIndex, metadata));
@@ -156,41 +129,18 @@ public class DetectNewPartitionsDoFn extends DoFn<ChangeStreamSourceDescriptor, 
         LOG.info("Scheduling partition: " + metadata);
         receiver.output(metadata);
 
-        // TODO(hengfeng): investigate if we can move this to DAO.
-        this.databaseClient
-            .readWriteTransaction()
-            .run(
-                transaction -> {
-                  // Update the record to SCHEDULED.
-                  // TODO(hengfeng): use mutations instead.
-                  Statement updateStatement =
-                      Statement.newBuilder(
-                              String.format(
-                                  "UPDATE `%s` "
-                                      + "SET State = 'SCHEDULED' "
-                                      + "WHERE PartitionToken = @PartitionToken",
-                                  this.metadataTableName))
-                          .bind("PartitionToken")
-                          .to(metadata.getPartitionToken())
-                          .build();
-                  transaction.executeUpdate(updateStatement);
-                  LOG.debug("Updated the record:" + metadata.getPartitionToken());
-                  return null;
-                });
+        partitionMetadataDao.updateState(metadata.getPartitionToken(), State.SCHEDULED);
+        LOG.debug("Updated the record:" + metadata.getPartitionToken());
       }
     }
 
-    // If there are no partitions in the table, we should stop this SDF
-    // function.
-    // TODO(hengfeng): move this query to DAO.
-    query = String.format("SELECT COUNT(*) FROM `%s`", this.metadataTableName);
-    try (ResultSet resultSet = this.databaseClient.singleUse().executeQuery(Statement.of(query))) {
-      if (resultSet.next() && resultSet.getLong(0) == 0) {
-        if (!tracker.tryClaim(tracker.currentRestriction().getTo() - 1)) {
-          LOG.warn("Failed to claim the end of range in DetectNewPartitionsDoFn.");
-        }
-        return ProcessContinuation.stop();
+    // If there are no partitions in the table, we should stop this SDF function.
+    long numOfPartitions = partitionMetadataDao.countPartitions();
+    if (numOfPartitions == 0) {
+      if (!tracker.tryClaim(tracker.currentRestriction().getTo() - 1)) {
+        LOG.warn("Failed to claim the end of range in DetectNewPartitionsDoFn.");
       }
+      return ProcessContinuation.stop();
     }
     return ProcessContinuation.resume().withResumeDelay(resumeDuration);
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/DetectNewPartitionsDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/DetectNewPartitionsDoFn.java
@@ -126,9 +126,11 @@ public class DetectNewPartitionsDoFn extends DoFn<ChangeStreamSourceDescriptor, 
           INITIAL_PARTITION_CREATED_TO_SCHEDULED_MS.update(
               new Duration(metadata.getCreatedAt().toDate().getTime(), Instant.now().getMillis())
                   .getMillis());
-        } else {PARTITION_CREATED_TO_SCHEDULED_MS.update(
-            new Duration(metadata.getCreatedAt().toDate().getTime(), Instant.now().getMillis())
-                .getMillis());}
+        } else {
+          PARTITION_CREATED_TO_SCHEDULED_MS.update(
+              new Duration(metadata.getCreatedAt().toDate().getTime(), Instant.now().getMillis())
+                  .getMillis());
+        }
         LOG.debug(
             String.format(
                 "Get partition metadata currentIndex:%d meta:%s", currentIndex, metadata));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/NameGenerator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/NameGenerator.java
@@ -25,7 +25,7 @@ public class NameGenerator {
   private static final String METADATA_TABLE_NAME_FORMAT = "CDC_Partitions_%s_%s";
 
   // TODO: Add java docs
-  public static String generateMetadataTableName(String databaseId) {
+  public static String generatePartitionMetadataTableName(String databaseId) {
     // Maximum Spanner table name length is 128 characters.
     // There are 16 characters in the name format.
     // Maximum Spanner database ID length is 30 characters.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/PipelineInitializer.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/PipelineInitializer.java
@@ -17,27 +17,9 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.cdc;
 
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_CREATED_AT;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_END_TIMESTAMP;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_HEARTBEAT_MILLIS;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_INCLUSIVE_END;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_INCLUSIVE_START;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_PARENT_TOKENS;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_PARTITION_TOKEN;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_START_TIMESTAMP;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_STATE;
-import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_UPDATED_AT;
-
-import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.Timestamp;
-import com.google.cloud.spanner.DatabaseAdminClient;
-import com.google.cloud.spanner.DatabaseId;
-import com.google.cloud.spanner.SpannerException;
-import com.google.cloud.spanner.SpannerExceptionFactory;
-import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataAdminDao;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.model.PartitionMetadata;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.model.PartitionMetadata.State;
@@ -46,63 +28,13 @@ public class PipelineInitializer {
 
   private static final long DEFAULT_HEARTBEAT_MILLIS = 5000;
 
-  // TODO: See if we can get away with not passing in the database id, but the generated table name
-  // instead
   public static void initialize(
-      DatabaseAdminClient databaseAdminClient,
+      PartitionMetadataAdminDao partitionMetadataAdminDao,
       PartitionMetadataDao partitionMetadataDao,
-      DatabaseId id,
-      String partitionMetadataTableName,
       Timestamp inclusiveStartAt,
       @Nullable Timestamp inclusiveEndAt) {
-    createMetadataTable(databaseAdminClient, id, partitionMetadataTableName);
+    partitionMetadataAdminDao.createPartitionMetadataTable();
     createFakeParentPartition(partitionMetadataDao, inclusiveStartAt, inclusiveEndAt);
-  }
-
-  private static void createMetadataTable(
-      DatabaseAdminClient databaseAdminClient, DatabaseId id, String tableName) {
-    final String metadataCreateStmt =
-        "CREATE TABLE "
-            + tableName
-            + " ("
-            + COLUMN_PARTITION_TOKEN
-            + " STRING(MAX) NOT NULL,"
-            + COLUMN_PARENT_TOKENS
-            + " ARRAY<STRING(MAX)> NOT NULL,"
-            + COLUMN_START_TIMESTAMP
-            + " TIMESTAMP NOT NULL,"
-            + COLUMN_INCLUSIVE_START
-            + " BOOL NOT NULL, "
-            + COLUMN_END_TIMESTAMP
-            + " TIMESTAMP,"
-            + COLUMN_INCLUSIVE_END
-            + " BOOL,"
-            + COLUMN_HEARTBEAT_MILLIS
-            + " INT64 NOT NULL,"
-            + COLUMN_STATE
-            + " STRING(MAX) NOT NULL,"
-            + COLUMN_CREATED_AT
-            + " TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),"
-            + COLUMN_UPDATED_AT
-            + " TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true)"
-            + ") PRIMARY KEY (PartitionToken)";
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
-        databaseAdminClient.updateDatabaseDdl(
-            id.getInstanceId().getInstance(),
-            id.getDatabase(),
-            Collections.singletonList(metadataCreateStmt),
-            null);
-    try {
-      // Initiate the request which returns an OperationFuture.
-      op.get();
-    } catch (ExecutionException e) {
-      // If the operation failed during execution, expose the cause.
-      throw (SpannerException) e.getCause();
-    } catch (InterruptedException e) {
-      // Throw when a thread is waiting, sleeping, or otherwise occupied,
-      // and the thread is interrupted, either before or during the activity.
-      throw SpannerExceptionFactory.propagateInterrupt(e);
-    }
   }
 
   private static void createFakeParentPartition(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/ReadChangeStreamPartitionDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/ReadChangeStreamPartitionDoFn.java
@@ -21,7 +21,6 @@ import com.google.cloud.spanner.ResultSet;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
-import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.actions.ActionFactory;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.actions.ChildPartitionsRecordAction;
 import org.apache.beam.sdk.io.gcp.spanner.cdc.actions.DataChangeRecordAction;
@@ -64,7 +63,6 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
   private static final long serialVersionUID = -7574596218085711975L;
   private static final Logger LOG = LoggerFactory.getLogger(ReadChangeStreamPartitionDoFn.class);
 
-  private final SpannerConfig spannerConfig;
   private final DaoFactory daoFactory;
   private final MapperFactory mapperFactory;
   private final ActionFactory actionFactory;
@@ -81,11 +79,7 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
   private transient DonePartitionAction donePartitionAction;
 
   public ReadChangeStreamPartitionDoFn(
-      SpannerConfig spannerConfig,
-      DaoFactory daoFactory,
-      MapperFactory mapperFactory,
-      ActionFactory actionFactory) {
-    this.spannerConfig = spannerConfig;
+      DaoFactory daoFactory, MapperFactory mapperFactory, ActionFactory actionFactory) {
     this.daoFactory = daoFactory;
     this.mapperFactory = mapperFactory;
     this.actionFactory = actionFactory;
@@ -115,9 +109,8 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
 
   @Setup
   public void setup() {
-    final PartitionMetadataDao partitionMetadataDao =
-        daoFactory.partitionMetadataDaoFrom(spannerConfig);
-    this.changeStreamDao = daoFactory.changeStreamDaoFrom(spannerConfig);
+    final PartitionMetadataDao partitionMetadataDao = daoFactory.getPartitionMetadataDao();
+    this.changeStreamDao = daoFactory.getChangeStreamDao();
     this.changeStreamRecordMapper = mapperFactory.changeStreamRecordMapper();
 
     this.waitForChildPartitionsAction =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/DaoFactory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.cdc.dao;
 
+import com.google.cloud.spanner.DatabaseAdminClient;
 import java.io.Serializable;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerAccessor;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
@@ -25,20 +26,46 @@ import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 public class DaoFactory implements Serializable {
 
   private static final long serialVersionUID = 7929063669009832487L;
+  private static PartitionMetadataAdminDao partitionMetadataAdminDao;
   private static PartitionMetadataDao partitionMetadataDaoInstance;
   private static ChangeStreamDao changeStreamDaoInstance;
+
+  private final SpannerConfig changeStreamSpannerConfig;
+  private final SpannerConfig partitionMetadataSpannerConfig;
 
   private final String changeStreamName;
   private final String partitionMetadataTableName;
 
-  public DaoFactory(String changeStreamName, String partitionMetadataTableName) {
+  public DaoFactory(
+      SpannerConfig changeStreamSpannerConfig,
+      String changeStreamName,
+      SpannerConfig partitionMetadataSpannerConfig,
+      String partitionMetadataTableName) {
+    this.changeStreamSpannerConfig = changeStreamSpannerConfig;
     this.changeStreamName = changeStreamName;
+    this.partitionMetadataSpannerConfig = partitionMetadataSpannerConfig;
     this.partitionMetadataTableName = partitionMetadataTableName;
   }
 
   // TODO: See if synchronized is a bottleneck and refactor if so
-  public synchronized PartitionMetadataDao partitionMetadataDaoFrom(SpannerConfig spannerConfig) {
-    final SpannerAccessor spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
+  public synchronized PartitionMetadataAdminDao getPartitionMetadataAdminDao() {
+    DatabaseAdminClient databaseAdminClient =
+        SpannerAccessor.getOrCreate(partitionMetadataSpannerConfig).getDatabaseAdminClient();
+    if (partitionMetadataAdminDao == null) {
+      partitionMetadataAdminDao =
+          new PartitionMetadataAdminDao(
+              databaseAdminClient,
+              partitionMetadataSpannerConfig.getInstanceId().get(),
+              partitionMetadataSpannerConfig.getDatabaseId().get(),
+              partitionMetadataTableName);
+    }
+    return partitionMetadataAdminDao;
+  }
+
+  // TODO: See if synchronized is a bottleneck and refactor if so
+  public synchronized PartitionMetadataDao getPartitionMetadataDao() {
+    final SpannerAccessor spannerAccessor =
+        SpannerAccessor.getOrCreate(partitionMetadataSpannerConfig);
     if (partitionMetadataDaoInstance == null) {
       partitionMetadataDaoInstance =
           new PartitionMetadataDao(
@@ -48,8 +75,8 @@ public class DaoFactory implements Serializable {
   }
 
   // TODO: See if synchronized is a bottleneck and refactor if so
-  public synchronized ChangeStreamDao changeStreamDaoFrom(SpannerConfig spannerConfig) {
-    final SpannerAccessor spannerAccessor = SpannerAccessor.getOrCreate(spannerConfig);
+  public synchronized ChangeStreamDao getChangeStreamDao() {
+    final SpannerAccessor spannerAccessor = SpannerAccessor.getOrCreate(changeStreamSpannerConfig);
     if (changeStreamDaoInstance == null) {
       changeStreamDaoInstance =
           new ChangeStreamDao(this.changeStreamName, spannerAccessor.getDatabaseClient());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/DaoFactory.java
@@ -49,9 +49,9 @@ public class DaoFactory implements Serializable {
 
   // TODO: See if synchronized is a bottleneck and refactor if so
   public synchronized PartitionMetadataAdminDao getPartitionMetadataAdminDao() {
-    DatabaseAdminClient databaseAdminClient =
-        SpannerAccessor.getOrCreate(partitionMetadataSpannerConfig).getDatabaseAdminClient();
     if (partitionMetadataAdminDao == null) {
+      DatabaseAdminClient databaseAdminClient =
+          SpannerAccessor.getOrCreate(partitionMetadataSpannerConfig).getDatabaseAdminClient();
       partitionMetadataAdminDao =
           new PartitionMetadataAdminDao(
               databaseAdminClient,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataAdminDao.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.cdc.dao;
+
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_CREATED_AT;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_END_TIMESTAMP;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_HEARTBEAT_MILLIS;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_INCLUSIVE_END;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_INCLUSIVE_START;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_PARENT_TOKENS;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_PARTITION_TOKEN;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_START_TIMESTAMP;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_STATE;
+import static org.apache.beam.sdk.io.gcp.spanner.cdc.dao.PartitionMetadataDao.COLUMN_UPDATED_AT;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.SpannerException;
+import com.google.cloud.spanner.SpannerExceptionFactory;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+
+// TODO: Add java docs
+public class PartitionMetadataAdminDao {
+
+  private final DatabaseAdminClient databaseAdminClient;
+  private final String instanceId;
+  private final String databaseId;
+  private final String tableName;
+
+  public PartitionMetadataAdminDao(
+      DatabaseAdminClient databaseAdminClient,
+      String instanceId,
+      String databaseId,
+      String tableName) {
+    this.databaseAdminClient = databaseAdminClient;
+    this.instanceId = instanceId;
+    this.databaseId = databaseId;
+    this.tableName = tableName;
+  }
+
+  public void createPartitionMetadataTable() {
+    final String metadataCreateStmt =
+        "CREATE TABLE "
+            + tableName
+            + " ("
+            + COLUMN_PARTITION_TOKEN
+            + " STRING(MAX) NOT NULL,"
+            + COLUMN_PARENT_TOKENS
+            + " ARRAY<STRING(MAX)> NOT NULL,"
+            + COLUMN_START_TIMESTAMP
+            + " TIMESTAMP NOT NULL,"
+            + COLUMN_INCLUSIVE_START
+            + " BOOL NOT NULL, "
+            + COLUMN_END_TIMESTAMP
+            + " TIMESTAMP,"
+            + COLUMN_INCLUSIVE_END
+            + " BOOL,"
+            + COLUMN_HEARTBEAT_MILLIS
+            + " INT64 NOT NULL,"
+            + COLUMN_STATE
+            + " STRING(MAX) NOT NULL,"
+            + COLUMN_CREATED_AT
+            + " TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true),"
+            + COLUMN_UPDATED_AT
+            + " TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true)"
+            + ") PRIMARY KEY (PartitionToken)";
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> op =
+        databaseAdminClient.updateDatabaseDdl(
+            instanceId, databaseId, Collections.singletonList(metadataCreateStmt), null);
+    try {
+      // Initiate the request which returns an OperationFuture.
+      op.get();
+    } catch (ExecutionException e) {
+      // If the operation failed during execution, expose the cause.
+      throw (SpannerException) e.getCause();
+    } catch (InterruptedException e) {
+      // Throw when a thread is waiting, sleeping, or otherwise occupied,
+      // and the thread is interrupted, either before or during the activity.
+      throw SpannerExceptionFactory.propagateInterrupt(e);
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataAdminDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataAdminDao.java
@@ -35,9 +35,13 @@ import com.google.cloud.spanner.SpannerExceptionFactory;
 import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 // TODO: Add java docs
 public class PartitionMetadataAdminDao {
+
+  private static final int TIMEOUT_MINUTES = 10;
 
   private final DatabaseAdminClient databaseAdminClient;
   private final String instanceId;
@@ -86,9 +90,9 @@ public class PartitionMetadataAdminDao {
             instanceId, databaseId, Collections.singletonList(metadataCreateStmt), null);
     try {
       // Initiate the request which returns an OperationFuture.
-      op.get();
-    } catch (ExecutionException e) {
-      // If the operation failed during execution, expose the cause.
+      op.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
+    } catch (ExecutionException | TimeoutException e) {
+      // If the operation failed or timed out during execution, expose the cause.
       throw (SpannerException) e.getCause();
     } catch (InterruptedException e) {
       // Throw when a thread is waiting, sleeping, or otherwise occupied,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataDao.java
@@ -105,6 +105,23 @@ public class PartitionMetadataDao {
     }
   }
 
+  public long countPartitions() {
+    Statement statement = Statement.newBuilder("SELECT COUNT(*) FROM " + tableName).build();
+    try (ResultSet resultSet = databaseClient.singleUse().executeQuery(statement)) {
+      resultSet.next();
+      return resultSet.getLong(0);
+    }
+  }
+
+  public ResultSet getPartitionsInState(State state) {
+    Statement statement =
+        Statement.newBuilder("SELECT * FROM " + tableName + " WHERE State = '@state'")
+            .bind("state")
+            .to(state.toString())
+            .build();
+    return databaseClient.singleUse().executeQuery(statement);
+  }
+
   public void insert(PartitionMetadata row) {
     runInTransaction(transaction -> transaction.insert(row));
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/cdc/dao/PartitionMetadataDao.java
@@ -115,7 +115,7 @@ public class PartitionMetadataDao {
 
   public ResultSet getPartitionsInState(State state) {
     Statement statement =
-        Statement.newBuilder("SELECT * FROM " + tableName + " WHERE State = '@state'")
+        Statement.newBuilder("SELECT * FROM " + tableName + " WHERE State = @state")
             .bind("state")
             .to(state.toString())
             .build();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/cdc/NameGeneratorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/cdc/NameGeneratorTest.java
@@ -28,14 +28,15 @@ public class NameGeneratorTest {
 
   @Test
   public void testGenerateMetadataTableNameRemovesHyphens() {
-    final String tableName = NameGenerator.generateMetadataTableName("my-database-id-12345");
+    final String tableName =
+        NameGenerator.generatePartitionMetadataTableName("my-database-id-12345");
     assertFalse(tableName.contains("-"));
   }
 
   @Test
   public void testGenerateMetadataTableNameIsShorterThan128Characters() {
     final String tableName =
-        NameGenerator.generateMetadataTableName("my-database-id1-maximum-length");
+        NameGenerator.generatePartitionMetadataTableName("my-database-id1-maximum-length");
     assertTrue(tableName.length() < MAXIMUM_TABLE_NAME_LENGTH);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/cdc/ReadChangeStreamPartitionDoFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/cdc/ReadChangeStreamPartitionDoFnTest.java
@@ -116,8 +116,7 @@ public class ReadChangeStreamPartitionDoFnTest {
     childPartitionsRecordAction = mock(ChildPartitionsRecordAction.class);
     changeStreamRecordMapper = mock(ChangeStreamRecordMapper.class);
 
-    doFn =
-        new ReadChangeStreamPartitionDoFn(spannerConfig, daoFactory, mapperFactory, actionFactory);
+    doFn = new ReadChangeStreamPartitionDoFn(daoFactory, mapperFactory, actionFactory);
 
     partition =
         PartitionMetadata.newBuilder()
@@ -137,8 +136,8 @@ public class ReadChangeStreamPartitionDoFnTest {
 
     when(restrictionTracker.currentRestriction()).thenReturn(restriction);
     when(restriction.getStartTimestamp()).thenReturn(PARTITION_START_TIMESTAMP);
-    when(daoFactory.partitionMetadataDaoFrom(spannerConfig)).thenReturn(partitionMetadataDao);
-    when(daoFactory.changeStreamDaoFrom(spannerConfig)).thenReturn(changeStreamDao);
+    when(daoFactory.getPartitionMetadataDao()).thenReturn(partitionMetadataDao);
+    when(daoFactory.getChangeStreamDao()).thenReturn(changeStreamDao);
     when(mapperFactory.changeStreamRecordMapper()).thenReturn(changeStreamRecordMapper);
     when(actionFactory.waitForChildPartitionsAction(partitionMetadataDao, resumeDuration))
         .thenReturn(waitForChildPartitionsAction);


### PR DESCRIPTION
* Allow users to specify the database that the partition metadata table should be added to
* Refactor everything DB related, including moving code into DAOs and tidying up