### PR TITLE
feat: allow user specified metadata instance

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1405,7 +1405,8 @@ public class SpannerIO {
           getInclusiveStartAt() != null,
           "SpannerIO.readChangeStream() requires the start time to be set.");
       if (getMetadataInstance() != null) {
-        checkArgument(getMetadataDatabase() != null,
+        checkArgument(
+            getMetadataDatabase() != null,
             "SpannerIO.readChangeStream() requires the metadata database to be set if metadata instance is set.");
       }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1404,6 +1404,10 @@ public class SpannerIO {
       checkArgument(
           getInclusiveStartAt() != null,
           "SpannerIO.readChangeStream() requires the start time to be set.");
+      if (getMetadataInstance() != null) {
+        checkArgument(getMetadataDatabase() != null,
+            "SpannerIO.readChangeStream() requires the metadata database to be set if metadata instance is set.");
+      }
 
       // Start time must be before end time
       if (getInclusiveEndAt() != null

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1416,8 +1416,9 @@ public class SpannerIO {
               getSpannerConfig().getProjectId().get(),
               getSpannerConfig().getInstanceId().get(),
               getSpannerConfig().getDatabaseId().get());
-      final String partitionMetadataInstanceId = MoreObjects
-          .firstNonNull(getMetadataInstance(), changeStreamDatabaseId.getInstanceId().getInstance());
+      final String partitionMetadataInstanceId =
+          MoreObjects.firstNonNull(
+              getMetadataInstance(), changeStreamDatabaseId.getInstanceId().getInstance());
       final String partitionMetadataDatabaseId =
           MoreObjects.firstNonNull(getMetadataDatabase(), changeStreamDatabaseId.getDatabase());
       final String partitionMetadataTableName =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1281,6 +1281,8 @@ public class SpannerIO {
 
     abstract String getChangeStreamName();
 
+    abstract String getMetadataInstance();
+
     abstract String getMetadataDatabase();
 
     abstract Timestamp getInclusiveStartAt();
@@ -1297,6 +1299,8 @@ public class SpannerIO {
       abstract Builder setSpannerConfig(SpannerConfig spannerConfig);
 
       abstract Builder setChangeStreamName(String changeStreamName);
+
+      abstract Builder setMetadataInstance(String metadataInstance);
 
       abstract Builder setMetadataDatabase(String metadataDatabase);
 
@@ -1350,6 +1354,11 @@ public class SpannerIO {
     /** Specifies the change stream name. */
     public ReadChangeStream withChangeStreamName(String changeStreamName) {
       return toBuilder().setChangeStreamName(changeStreamName).build();
+    }
+
+    /** Specifies the metadata database. */
+    public ReadChangeStream withMetadataInstance(String metadataInstance) {
+      return toBuilder().setMetadataInstance(metadataInstance).build();
     }
 
     /** Specifies the metadata database. */
@@ -1407,6 +1416,8 @@ public class SpannerIO {
               getSpannerConfig().getProjectId().get(),
               getSpannerConfig().getInstanceId().get(),
               getSpannerConfig().getDatabaseId().get());
+      final String partitionMetadataInstanceId = MoreObjects
+          .firstNonNull(getMetadataInstance(), changeStreamDatabaseId.getInstanceId().getInstance());
       final String partitionMetadataDatabaseId =
           MoreObjects.firstNonNull(getMetadataDatabase(), changeStreamDatabaseId.getDatabase());
       final String partitionMetadataTableName =
@@ -1416,8 +1427,8 @@ public class SpannerIO {
       final SpannerConfig partitionMetadataSpannerConfig =
           SpannerConfig.create()
               .withProjectId(changeStreamSpannerConfig.getProjectId())
-              .withInstanceId(changeStreamSpannerConfig.getInstanceId())
               .withHost(changeStreamSpannerConfig.getHost())
+              .withInstanceId(partitionMetadataInstanceId)
               .withDatabaseId(partitionMetadataDatabaseId)
               .withCommitDeadline(changeStreamSpannerConfig.getCommitDeadline())
               .withEmulatorHost(changeStreamSpannerConfig.getEmulatorHost())


### PR DESCRIPTION
Since we're using AutoValue, I couldn't think of a way to accept two parameters (instance and database) in the same setter, other than creating a new class with the two params as fields. I've added the instance as a separate setter directly in `ReadChangeStream` for now for simplicity. Let me know if you'd prefer other approaches.